### PR TITLE
[FE-#38] Add event data for apps in environment file

### DIFF
--- a/apps/app/src/_services/event.service.ts
+++ b/apps/app/src/_services/event.service.ts
@@ -1,9 +1,9 @@
-import { Injectable } from '@angular/core';
-import { Observable } from 'rxjs';
-import { IEvent } from '@conferentia/models';
-import { environment } from '../environments/environment';
-import { HttpService } from './http.service';
+import { BehaviorSubject, Observable, of, switchMap } from 'rxjs';
 import { HttpClient } from '@angular/common/http';
+import { HttpService } from './http.service';
+import { IEvent } from '@conferentia/models';
+import { Injectable } from '@angular/core';
+import { environment } from '../environments/environment';
 
 @Injectable({
   providedIn: 'root',
@@ -11,11 +11,26 @@ import { HttpClient } from '@angular/common/http';
 export class EventService extends HttpService {
   protected prefix = `${environment.apiUrl}/event`;
 
+  private currentEvent$: BehaviorSubject<IEvent | null> =
+    new BehaviorSubject<IEvent | null>(null);
+
   constructor(protected override http: HttpClient) {
     super(http);
   }
 
-  public get(id: number): Observable<IEvent> {
+  public get(id: number | string): Observable<IEvent> {
     return this.http.get<IEvent>(`${this.prefix}/${id}`);
+  }
+
+  // Used to set the current event at app boostrapping by
+  // reading the app environment.ts file
+  // TODO: Load event data based on SaaS-oriented configuration (2022/11/04 - RO - #40)
+  public setFromEnvironment(): Observable<IEvent> {
+    return this.get(environment.eventId).pipe(
+      switchMap((event) => {
+        this.currentEvent$.next(event);
+        return of(event);
+      })
+    );
   }
 }

--- a/apps/app/src/app/app.module.ts
+++ b/apps/app/src/app/app.module.ts
@@ -1,4 +1,4 @@
-import { NgModule } from '@angular/core';
+import { APP_INITIALIZER, FactoryProvider, NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { RouteReuseStrategy } from '@angular/router';
 
@@ -9,18 +9,34 @@ import { AppRoutingModule } from './app-routing.module';
 import { HttpClientModule } from '@angular/common/http';
 import { EventService } from '../_services/event.service';
 
+// TODO: Load event data based on SaaS-oriented configuration (2022/11/04 - RO - #40)
+export const loadCurrentEvent: FactoryProvider = {
+  provide: APP_INITIALIZER,
+  useFactory: loadEventFactory,
+  deps: [EventService],
+  multi: true,
+};
+
+function loadEventFactory(eventService: EventService) {
+  return () => eventService.setFromEnvironment();
+}
+
 @NgModule({
-    declarations: [AppComponent],
-    imports: [
-        BrowserModule,
-        IonicModule.forRoot(),
-        AppRoutingModule,
-        HttpClientModule,
-    ],
-    providers: [
-        EventService,
-        { provide: RouteReuseStrategy, useClass: IonicRouteStrategy },
-    ],
-    bootstrap: [AppComponent]
+  declarations: [AppComponent],
+  imports: [
+    BrowserModule,
+    IonicModule.forRoot(),
+    AppRoutingModule,
+    HttpClientModule,
+  ],
+  providers: [
+    EventService,
+    // TODO: Load event data based on SaaS-oriented configuration (2022/11/04 - RO - #40)
+    loadCurrentEvent,
+    { provide: RouteReuseStrategy, useClass: IonicRouteStrategy },
+  ],
+  bootstrap: [AppComponent],
 })
 export class AppModule {}
+
+

--- a/apps/app/src/environments/environment.prod.ts
+++ b/apps/app/src/environments/environment.prod.ts
@@ -1,6 +1,8 @@
-export const environment = {
+import { IFrontendEnvironmentConfig } from '@conferentia/models';
+
+export const environment: IFrontendEnvironmentConfig = {
   production: true,
   //TODO: Move these configuration to .env file and consume it from there (2022/11/04 - RO - #39)
   apiUrl: '',
-  eventId: 'c848063b-a2d3-4817-b248-51bef7453fce'
+  eventId: 'c848063b-a2d3-4817-b248-51bef7453fce',
 };

--- a/apps/app/src/environments/environment.prod.ts
+++ b/apps/app/src/environments/environment.prod.ts
@@ -1,4 +1,6 @@
 export const environment = {
   production: true,
+  //TODO: Move these configuration to .env file and consume it from there (2022/11/04 - RO - #39)
   apiUrl: '',
+  eventId: 'c848063b-a2d3-4817-b248-51bef7453fce'
 };

--- a/apps/app/src/environments/environment.ts
+++ b/apps/app/src/environments/environment.ts
@@ -4,8 +4,9 @@
 
 export const environment = {
   production: false,
-  //TODO: Move this configuration to .env file and consume it from there
+  //TODO: Move these configuration to .env file and consume it from there (2022/11/04 - RO - #39)
   apiUrl: 'http://localhost:3334/api',
+  eventId: 'c848063b-a2d3-4817-b248-51bef7453fce'
 };
 
 /*

--- a/apps/app/src/environments/environment.ts
+++ b/apps/app/src/environments/environment.ts
@@ -2,11 +2,13 @@
 // `ng build` replaces `environment.ts` with `environment.prod.ts`.
 // The list of file replacements can be found in `angular.json`.
 
-export const environment = {
+import { IFrontendEnvironmentConfig } from '@conferentia/models';
+
+export const environment: IFrontendEnvironmentConfig = {
   production: false,
   //TODO: Move these configuration to .env file and consume it from there (2022/11/04 - RO - #39)
   apiUrl: 'http://localhost:3334/api',
-  eventId: 'c848063b-a2d3-4817-b248-51bef7453fce'
+  eventId: 'c848063b-a2d3-4817-b248-51bef7453fce',
 };
 
 /*

--- a/libs/models/src/index.ts
+++ b/libs/models/src/index.ts
@@ -1,2 +1,6 @@
+// Domain models
 export { IEvent } from './lib/event.interface';
 export { IActivity } from './lib/activity.interface';
+
+// Infrastructure-related models
+export { IFrontendEnvironmentConfig } from './lib/fe-environment.interface';

--- a/libs/models/src/index.ts
+++ b/libs/models/src/index.ts
@@ -1,6 +1,12 @@
 // Domain models
 export { IEvent } from './lib/event.interface';
 export { IActivity } from './lib/activity.interface';
+export { IActivityType } from './lib/activity-type.interface';
+export { IAttendance } from './lib/attendance.interface';
+export { IAttendee } from './lib/attendee.interface';
+export { IParticipant } from './lib/participant.interface';
+
+export { IAudit } from './lib/audit.interface';
 
 // Infrastructure-related models
-export { IFrontendEnvironmentConfig } from './lib/fe-environment.interface';
+export { IFrontendEnvironmentConfig } from './lib/frontend-environment-config.interface';

--- a/libs/models/src/lib/frontend-environment-config.interface.ts
+++ b/libs/models/src/lib/frontend-environment-config.interface.ts
@@ -1,0 +1,6 @@
+export interface IFrontendEnvironmentConfig {
+  production: boolean;
+  apiUrl: string;
+  //TODO: Check if eventId is still required after moving the config to .env files (2022/11/04 - RO - #39)
+  eventId: string;
+}


### PR DESCRIPTION
# Summary
* Added `eventId` property to environment config files.
* Applied typing to environment config definitions.
* Loaded the current event data from `EventService` at startup.
  * Added new `setFromEnvironment()` method to load event at APP_INITIALIZER provider.

## Other changes
* Added the `IFrontendEnvironmentConfig` model to models lib.
* Exported all missing model definitions from models lib.
