### PR TITLE
[FE-#49] - Fix title and menu icon not being shown correctly in mobile

### DIFF
--- a/apps/app/src/app/app.component.html
+++ b/apps/app/src/app/app.component.html
@@ -30,15 +30,6 @@
         </ion-list>
       </ion-content>
     </ion-menu>
-    <div id="main-content">
-      <ion-header>
-        <ion-toolbar>
-          <ion-title *ngIf="currentRoute$ | async as currentPage">
-            {{ currentPage.data.title }}</ion-title
-          >
-        </ion-toolbar>
-      </ion-header>
-      <ion-router-outlet></ion-router-outlet>
-    </div>
+    <ion-router-outlet id="main-content"></ion-router-outlet>
   </ion-split-pane>
 </ion-app>

--- a/apps/app/src/app/app.component.ts
+++ b/apps/app/src/app/app.component.ts
@@ -1,6 +1,6 @@
 import { ActivatedRoute, Router, RoutesRecognized } from '@angular/router';
 import { Component, inject, OnInit } from '@angular/core';
-import { filter, map, Observable, of } from 'rxjs';
+import { filter, map, Observable, of, Subject, takeUntil } from "rxjs";
 
 // Models
 import {
@@ -9,7 +9,7 @@ import {
 } from '@conferentia/models';
 
 // Services
-import { EventService } from '@conferentia/angular-services';
+import { EventService, NavigationService } from "@conferentia/angular-services";
 import { appRoutes } from './app-routing.module';
 
 @Component({
@@ -18,31 +18,37 @@ import { appRoutes } from './app-routing.module';
   styleUrls: ['app.component.scss'],
 })
 export class AppComponent implements OnInit {
-  // TODO: Assign the navigable pages info reading the routes data (2022/11/04 - RO - #43)
-  // TODO: Assign type to appPage objects (2022/11/04 - RO - #43)
-
   public appPages: ConferentiaRouteData[] = appRoutes
     .filter((route) => !!route.data)
     .map((route) => route.data) as ConferentiaRouteData[];
 
   // TODO: Assign type to currentRoute$ observable and content (2022/11/04 - RO - #43)
-  public currentRoute$: Observable<any> = of(null);
   public currentEvent$: Observable<IEvent | null> = of(null);
 
-  constructor(private route: ActivatedRoute, private router: Router) {
+  private destroyed$: Subject<boolean> = new Subject();
+
+  constructor(private navigationService: NavigationService, private route: ActivatedRoute, private router: Router) {
     const eventService: EventService = inject(EventService);
     this.currentEvent$ = eventService.currentEvent$;
   }
 
   ngOnInit() {
     // TODO: Improve solution to determine the active route and assign the corresponding header (2022/11/04 - RO - #43)
-    this.currentRoute$ = this.router.events.pipe(
+    this.router.events.pipe(
+      takeUntil(this.destroyed$),
       filter(
         (event): event is RoutesRecognized => event instanceof RoutesRecognized
       ),
       map((event: RoutesRecognized) => {
         return event.state.root.firstChild;
-      })
-    );
+      }),
+    ).subscribe(route => {
+      this.navigationService.currentRoute$.next(route)
+    });
+  }
+
+  ngOnDestroy() {
+    this.destroyed$.next(true);
+    this.destroyed$.complete();
   }
 }

--- a/apps/app/src/app/app.module.ts
+++ b/apps/app/src/app/app.module.ts
@@ -10,6 +10,7 @@ import { HttpClientModule } from '@angular/common/http';
 import {
   AngularServicesModule,
   EventService,
+  NavigationService,
 } from '@conferentia/angular-services';
 
 // Environment
@@ -39,6 +40,7 @@ function loadEventFactory(eventService: EventService) {
   ],
   providers: [
     EventService,
+    NavigationService,
     // TODO: Load event data based on SaaS-oriented configuration (2022/11/04 - RO - #40)
     loadCurrentEvent,
     { provide: RouteReuseStrategy, useClass: IonicRouteStrategy },

--- a/apps/app/src/app/home/home.module.ts
+++ b/apps/app/src/app/home/home.module.ts
@@ -7,9 +7,10 @@ import { IonicModule } from '@ionic/angular';
 import { HomePageRoutingModule } from './home-routing.module';
 
 import { HomePage } from './home.page';
+import { IonicComponentsModule } from "@conferentia/ionic-components";
 
 @NgModule({
-  imports: [CommonModule, FormsModule, IonicModule, HomePageRoutingModule],
+  imports: [CommonModule, FormsModule, IonicModule, HomePageRoutingModule, IonicComponentsModule],
   declarations: [HomePage],
 })
 export class HomePageModule {}

--- a/apps/app/src/app/home/home.page.html
+++ b/apps/app/src/app/home/home.page.html
@@ -1,1 +1,5 @@
-<ion-content> </ion-content>
+<conferentia-fillable-content-page [content]="homeContent"></conferentia-fillable-content-page>
+
+<ng-template #homeContent>
+  This is the home content.
+</ng-template>

--- a/apps/app/src/app/participants/participants.module.ts
+++ b/apps/app/src/app/participants/participants.module.ts
@@ -7,6 +7,7 @@ import { IonicModule } from '@ionic/angular';
 import { ParticipantsPageRoutingModule } from './participants-routing.module';
 
 import { ParticipantsPage } from './participants.page';
+import { IonicComponentsModule } from "@conferentia/ionic-components";
 
 @NgModule({
   imports: [
@@ -14,6 +15,7 @@ import { ParticipantsPage } from './participants.page';
     FormsModule,
     IonicModule,
     ParticipantsPageRoutingModule,
+    IonicComponentsModule
   ],
   declarations: [ParticipantsPage],
 })

--- a/apps/app/src/app/participants/participants.page.html
+++ b/apps/app/src/app/participants/participants.page.html
@@ -1,1 +1,5 @@
-<ion-content> </ion-content>
+<conferentia-fillable-content-page [content]="participantsContent"></conferentia-fillable-content-page>
+
+<ng-template #participantsContent>
+  This is the Participants content.
+</ng-template>

--- a/apps/app/src/app/registration/registration.module.ts
+++ b/apps/app/src/app/registration/registration.module.ts
@@ -7,6 +7,7 @@ import { IonicModule } from '@ionic/angular';
 import { RegistrationPageRoutingModule } from './registration-routing.module';
 
 import { RegistrationPage } from './registration.page';
+import { IonicComponentsModule } from "@conferentia/ionic-components";
 
 @NgModule({
   imports: [
@@ -14,6 +15,7 @@ import { RegistrationPage } from './registration.page';
     FormsModule,
     IonicModule,
     RegistrationPageRoutingModule,
+    IonicComponentsModule
   ],
   declarations: [RegistrationPage],
 })

--- a/apps/app/src/app/registration/registration.page.html
+++ b/apps/app/src/app/registration/registration.page.html
@@ -1,1 +1,5 @@
-<ion-content> </ion-content>
+<conferentia-fillable-content-page [content]="registrationContent"></conferentia-fillable-content-page>
+
+<ng-template #registrationContent>
+  This is the Registration content.
+</ng-template>

--- a/apps/app/src/app/schedule/schedule.module.ts
+++ b/apps/app/src/app/schedule/schedule.module.ts
@@ -7,9 +7,10 @@ import { IonicModule } from '@ionic/angular';
 import { SchedulePageRoutingModule } from './schedule-routing.module';
 
 import { SchedulePage } from './schedule.page';
+import { IonicComponentsModule } from "@conferentia/ionic-components";
 
 @NgModule({
-  imports: [CommonModule, FormsModule, IonicModule, SchedulePageRoutingModule],
+  imports: [CommonModule, FormsModule, IonicModule, SchedulePageRoutingModule, IonicComponentsModule],
   declarations: [SchedulePage],
 })
 export class SchedulePageModule {}

--- a/apps/app/src/app/schedule/schedule.page.html
+++ b/apps/app/src/app/schedule/schedule.page.html
@@ -1,1 +1,5 @@
-<ion-content> </ion-content>
+<conferentia-fillable-content-page [content]="scheduleContent"></conferentia-fillable-content-page>
+
+<ng-template #scheduleContent>
+  This is the Schedule content.
+</ng-template>

--- a/apps/app/src/app/sponsors/sponsors.module.ts
+++ b/apps/app/src/app/sponsors/sponsors.module.ts
@@ -7,9 +7,10 @@ import { IonicModule } from '@ionic/angular';
 import { SponsorsPageRoutingModule } from './sponsors-routing.module';
 
 import { SponsorsPage } from './sponsors.page';
+import { IonicComponentsModule } from "@conferentia/ionic-components";
 
 @NgModule({
-  imports: [CommonModule, FormsModule, IonicModule, SponsorsPageRoutingModule],
+  imports: [CommonModule, FormsModule, IonicModule, SponsorsPageRoutingModule, IonicComponentsModule],
   declarations: [SponsorsPage],
 })
 export class SponsorsPageModule {}

--- a/apps/app/src/app/sponsors/sponsors.page.html
+++ b/apps/app/src/app/sponsors/sponsors.page.html
@@ -1,1 +1,5 @@
-<ion-content> </ion-content>
+<conferentia-fillable-content-page [content]="sponsorsContent"></conferentia-fillable-content-page>
+
+<ng-template #sponsorsContent>
+  This is the Sponsors content.
+</ng-template>

--- a/apps/landing-unl-seminar-v1/src/app/app.component.html
+++ b/apps/landing-unl-seminar-v1/src/app/app.component.html
@@ -30,15 +30,6 @@
         </ion-list>
       </ion-content>
     </ion-menu>
-    <div id="main-content">
-      <ion-header>
-        <ion-toolbar>
-          <ion-title *ngIf="currentRoute$ | async as currentPage">
-            {{ currentPage.data.title }}</ion-title
-          >
-        </ion-toolbar>
-      </ion-header>
-      <ion-router-outlet></ion-router-outlet>
-    </div>
+    <ion-router-outlet id="main-content"></ion-router-outlet>
   </ion-split-pane>
 </ion-app>

--- a/apps/landing-unl-seminar-v1/src/app/app.module.ts
+++ b/apps/landing-unl-seminar-v1/src/app/app.module.ts
@@ -9,8 +9,8 @@ import { AppRoutingModule } from './app-routing.module';
 import { HttpClientModule } from '@angular/common/http';
 import {
   AngularServicesModule,
-  EventService,
-} from '@conferentia/angular-services';
+  EventService, NavigationService
+} from "@conferentia/angular-services";
 
 // Environment
 import { environment } from '../environments/environment';
@@ -39,6 +39,7 @@ function loadEventFactory(eventService: EventService) {
   ],
   providers: [
     EventService,
+    NavigationService,
     // TODO: Load event data based on SaaS-oriented configuration (2022/11/04 - RO - #40)
     loadCurrentEvent,
     { provide: RouteReuseStrategy, useClass: IonicRouteStrategy },

--- a/apps/landing-unl-seminar-v1/src/app/call-for-papers/call-for-papers.module.ts
+++ b/apps/landing-unl-seminar-v1/src/app/call-for-papers/call-for-papers.module.ts
@@ -7,6 +7,7 @@ import { IonicModule } from '@ionic/angular';
 import { CallForPapersPageRoutingModule } from './call-for-papers-routing.module';
 
 import { CallForPapersPage } from './call-for-papers.page';
+import { IonicComponentsModule } from "@conferentia/ionic-components";
 
 @NgModule({
   imports: [
@@ -14,6 +15,7 @@ import { CallForPapersPage } from './call-for-papers.page';
     FormsModule,
     IonicModule,
     CallForPapersPageRoutingModule,
+    IonicComponentsModule
   ],
   declarations: [CallForPapersPage],
 })

--- a/apps/landing-unl-seminar-v1/src/app/call-for-papers/call-for-papers.page.html
+++ b/apps/landing-unl-seminar-v1/src/app/call-for-papers/call-for-papers.page.html
@@ -1,7 +1,5 @@
-<ion-header>
-  <ion-toolbar>
-    <ion-title>CallForPapers</ion-title>
-  </ion-toolbar>
-</ion-header>
+<conferentia-fillable-content-page [content]="abstractsSubmissionContent"></conferentia-fillable-content-page>
 
-<ion-content> </ion-content>
+<ng-template #abstractsSubmissionContent>
+  This is the Abstracts Submission content.
+</ng-template>

--- a/apps/landing-unl-seminar-v1/src/app/committees/committees.module.ts
+++ b/apps/landing-unl-seminar-v1/src/app/committees/committees.module.ts
@@ -7,6 +7,7 @@ import { IonicModule } from '@ionic/angular';
 import { CommitteesPageRoutingModule } from './committees-routing.module';
 
 import { CommitteesPage } from './committees.page';
+import { IonicComponentsModule } from "@conferentia/ionic-components";
 
 @NgModule({
   imports: [
@@ -14,6 +15,7 @@ import { CommitteesPage } from './committees.page';
     FormsModule,
     IonicModule,
     CommitteesPageRoutingModule,
+    IonicComponentsModule
   ],
   declarations: [CommitteesPage],
 })

--- a/apps/landing-unl-seminar-v1/src/app/committees/committees.page.html
+++ b/apps/landing-unl-seminar-v1/src/app/committees/committees.page.html
@@ -1,7 +1,6 @@
-<ion-header>
-  <ion-toolbar>
-    <ion-title>Committees</ion-title>
-  </ion-toolbar>
-</ion-header>
+<conferentia-fillable-content-page [content]="committeesContent"></conferentia-fillable-content-page>
 
-<ion-content> </ion-content>
+<ng-template #committeesContent>
+  This is the Committees content.
+</ng-template>
+

--- a/apps/landing-unl-seminar-v1/src/app/contact/contact.module.ts
+++ b/apps/landing-unl-seminar-v1/src/app/contact/contact.module.ts
@@ -7,9 +7,10 @@ import { IonicModule } from '@ionic/angular';
 import { ContactPageRoutingModule } from './contact-routing.module';
 
 import { ContactPage } from './contact.page';
+import { IonicComponentsModule } from "@conferentia/ionic-components";
 
 @NgModule({
-  imports: [CommonModule, FormsModule, IonicModule, ContactPageRoutingModule],
+  imports: [CommonModule, FormsModule, IonicModule, ContactPageRoutingModule, IonicComponentsModule],
   declarations: [ContactPage],
 })
 export class ContactPageModule {}

--- a/apps/landing-unl-seminar-v1/src/app/contact/contact.page.html
+++ b/apps/landing-unl-seminar-v1/src/app/contact/contact.page.html
@@ -1,7 +1,6 @@
-<ion-header>
-  <ion-toolbar>
-    <ion-title>Contact</ion-title>
-  </ion-toolbar>
-</ion-header>
+<conferentia-fillable-content-page [content]="contactContent"></conferentia-fillable-content-page>
 
-<ion-content> </ion-content>
+<ng-template #contactContent>
+  This is the Contact content.
+</ng-template>
+

--- a/apps/landing-unl-seminar-v1/src/app/general-information/general-information.module.ts
+++ b/apps/landing-unl-seminar-v1/src/app/general-information/general-information.module.ts
@@ -7,6 +7,7 @@ import { IonicModule } from '@ionic/angular';
 import { GeneralInformationPageRoutingModule } from './general-information-routing.module';
 
 import { GeneralInformationPage } from './general-information.page';
+import { IonicComponentsModule } from "@conferentia/ionic-components";
 
 @NgModule({
   imports: [
@@ -14,6 +15,7 @@ import { GeneralInformationPage } from './general-information.page';
     FormsModule,
     IonicModule,
     GeneralInformationPageRoutingModule,
+    IonicComponentsModule
   ],
   declarations: [GeneralInformationPage],
 })

--- a/apps/landing-unl-seminar-v1/src/app/general-information/general-information.page.html
+++ b/apps/landing-unl-seminar-v1/src/app/general-information/general-information.page.html
@@ -1,7 +1,5 @@
-<ion-header>
-  <ion-toolbar>
-    <ion-title>GeneralInformation</ion-title>
-  </ion-toolbar>
-</ion-header>
+<conferentia-fillable-content-page [content]="generalInformationContent"></conferentia-fillable-content-page>
 
-<ion-content> </ion-content>
+<ng-template #generalInformationContent>
+  This is the General Information content.
+</ng-template>

--- a/apps/landing-unl-seminar-v1/src/app/home/home.module.ts
+++ b/apps/landing-unl-seminar-v1/src/app/home/home.module.ts
@@ -7,9 +7,10 @@ import { IonicModule } from '@ionic/angular';
 import { HomePageRoutingModule } from './home-routing.module';
 
 import { HomePage } from './home.page';
+import { IonicComponentsModule } from "@conferentia/ionic-components";
 
 @NgModule({
-  imports: [CommonModule, FormsModule, IonicModule, HomePageRoutingModule],
+  imports: [CommonModule, FormsModule, IonicModule, HomePageRoutingModule, IonicComponentsModule],
   declarations: [HomePage],
 })
 export class HomePageModule {}

--- a/apps/landing-unl-seminar-v1/src/app/home/home.page.html
+++ b/apps/landing-unl-seminar-v1/src/app/home/home.page.html
@@ -1,7 +1,5 @@
-<ion-header>
-  <ion-toolbar>
-    <ion-title>Home</ion-title>
-  </ion-toolbar>
-</ion-header>
+<conferentia-fillable-content-page [content]="homeContent"></conferentia-fillable-content-page>
 
-<ion-content> </ion-content>
+<ng-template #homeContent>
+  This is the home content.
+</ng-template>

--- a/apps/landing-unl-seminar-v1/src/app/keynote-speakers/keynote-speakers.module.ts
+++ b/apps/landing-unl-seminar-v1/src/app/keynote-speakers/keynote-speakers.module.ts
@@ -7,6 +7,7 @@ import { IonicModule } from '@ionic/angular';
 import { KeynoteSpeakersPageRoutingModule } from './keynote-speakers-routing.module';
 
 import { KeynoteSpeakersPage } from './keynote-speakers.page';
+import { IonicComponentsModule } from "@conferentia/ionic-components";
 
 @NgModule({
   imports: [
@@ -14,6 +15,7 @@ import { KeynoteSpeakersPage } from './keynote-speakers.page';
     FormsModule,
     IonicModule,
     KeynoteSpeakersPageRoutingModule,
+    IonicComponentsModule
   ],
   declarations: [KeynoteSpeakersPage],
 })

--- a/apps/landing-unl-seminar-v1/src/app/keynote-speakers/keynote-speakers.page.html
+++ b/apps/landing-unl-seminar-v1/src/app/keynote-speakers/keynote-speakers.page.html
@@ -1,7 +1,5 @@
-<ion-header>
-  <ion-toolbar>
-    <ion-title>KeynoteSpeakers</ion-title>
-  </ion-toolbar>
-</ion-header>
+<conferentia-fillable-content-page [content]="keynoteSpeakersContent"></conferentia-fillable-content-page>
 
-<ion-content> </ion-content>
+<ng-template #keynoteSpeakersContent>
+  This is the Contact content.
+</ng-template>

--- a/apps/landing-unl-seminar-v1/src/app/oral-presentations/oral-presentations.module.ts
+++ b/apps/landing-unl-seminar-v1/src/app/oral-presentations/oral-presentations.module.ts
@@ -7,6 +7,7 @@ import { IonicModule } from '@ionic/angular';
 import { OralPresentationsPageRoutingModule } from './oral-presentations-routing.module';
 
 import { OralPresentationsPage } from './oral-presentations.page';
+import { IonicComponentsModule } from "@conferentia/ionic-components";
 
 @NgModule({
   imports: [
@@ -14,6 +15,7 @@ import { OralPresentationsPage } from './oral-presentations.page';
     FormsModule,
     IonicModule,
     OralPresentationsPageRoutingModule,
+    IonicComponentsModule
   ],
   declarations: [OralPresentationsPage],
 })

--- a/apps/landing-unl-seminar-v1/src/app/oral-presentations/oral-presentations.page.html
+++ b/apps/landing-unl-seminar-v1/src/app/oral-presentations/oral-presentations.page.html
@@ -1,7 +1,5 @@
-<ion-header>
-  <ion-toolbar>
-    <ion-title>OralPresentations</ion-title>
-  </ion-toolbar>
-</ion-header>
+<conferentia-fillable-content-page [content]="oralPresentationsContent"></conferentia-fillable-content-page>
 
-<ion-content> </ion-content>
+<ng-template #oralPresentationsContent>
+  This is the Contact content.
+</ng-template>

--- a/apps/landing-unl-seminar-v1/src/app/registration/registration.module.ts
+++ b/apps/landing-unl-seminar-v1/src/app/registration/registration.module.ts
@@ -7,6 +7,7 @@ import { IonicModule } from '@ionic/angular';
 import { RegistrationPageRoutingModule } from './registration-routing.module';
 
 import { RegistrationPage } from './registration.page';
+import { IonicComponentsModule } from "@conferentia/ionic-components";
 
 @NgModule({
   imports: [
@@ -14,6 +15,7 @@ import { RegistrationPage } from './registration.page';
     FormsModule,
     IonicModule,
     RegistrationPageRoutingModule,
+    IonicComponentsModule
   ],
   declarations: [RegistrationPage],
 })

--- a/apps/landing-unl-seminar-v1/src/app/registration/registration.page.html
+++ b/apps/landing-unl-seminar-v1/src/app/registration/registration.page.html
@@ -1,7 +1,5 @@
-<ion-header>
-  <ion-toolbar>
-    <ion-title>Registration</ion-title>
-  </ion-toolbar>
-</ion-header>
+<conferentia-fillable-content-page [content]="registrationContent"></conferentia-fillable-content-page>
 
-<ion-content> </ion-content>
+<ng-template #registrationContent>
+  This is the Registration content.
+</ng-template>

--- a/apps/landing-unl-seminar-v1/src/app/schedule/schedule.module.ts
+++ b/apps/landing-unl-seminar-v1/src/app/schedule/schedule.module.ts
@@ -7,9 +7,10 @@ import { IonicModule } from '@ionic/angular';
 import { SchedulePageRoutingModule } from './schedule-routing.module';
 
 import { SchedulePage } from './schedule.page';
+import { IonicComponentsModule } from "@conferentia/ionic-components";
 
 @NgModule({
-  imports: [CommonModule, FormsModule, IonicModule, SchedulePageRoutingModule],
+  imports: [CommonModule, FormsModule, IonicModule, SchedulePageRoutingModule, IonicComponentsModule],
   declarations: [SchedulePage],
 })
 export class SchedulePageModule {}

--- a/apps/landing-unl-seminar-v1/src/app/schedule/schedule.page.html
+++ b/apps/landing-unl-seminar-v1/src/app/schedule/schedule.page.html
@@ -1,7 +1,5 @@
-<ion-header>
-  <ion-toolbar>
-    <ion-title>Schedule</ion-title>
-  </ion-toolbar>
-</ion-header>
+<conferentia-fillable-content-page [content]="scheduleContent"></conferentia-fillable-content-page>
 
-<ion-content> </ion-content>
+<ng-template #scheduleContent>
+  This is the Schedule content.
+</ng-template>

--- a/apps/landing-unl-seminar-v1/src/app/travel-information/travel-information.module.ts
+++ b/apps/landing-unl-seminar-v1/src/app/travel-information/travel-information.module.ts
@@ -7,6 +7,7 @@ import { IonicModule } from '@ionic/angular';
 import { TravelInformationPageRoutingModule } from './travel-information-routing.module';
 
 import { TravelInformationPage } from './travel-information.page';
+import { IonicComponentsModule } from "@conferentia/ionic-components";
 
 @NgModule({
   imports: [
@@ -14,6 +15,7 @@ import { TravelInformationPage } from './travel-information.page';
     FormsModule,
     IonicModule,
     TravelInformationPageRoutingModule,
+    IonicComponentsModule
   ],
   declarations: [TravelInformationPage],
 })

--- a/apps/landing-unl-seminar-v1/src/app/travel-information/travel-information.page.html
+++ b/apps/landing-unl-seminar-v1/src/app/travel-information/travel-information.page.html
@@ -1,7 +1,5 @@
-<ion-header>
-  <ion-toolbar>
-    <ion-title>TravelInformation</ion-title>
-  </ion-toolbar>
-</ion-header>
+<conferentia-fillable-content-page [content]="travelInformationContent"></conferentia-fillable-content-page>
 
-<ion-content> </ion-content>
+<ng-template #travelInformationContent>
+  This is the Travel Information content.
+</ng-template>

--- a/apps/landing-unl-seminar-v1/src/environments/environment.prod.ts
+++ b/apps/landing-unl-seminar-v1/src/environments/environment.prod.ts
@@ -3,6 +3,6 @@ import { IFrontendEnvironmentConfig } from '@conferentia/models';
 export const environment: IFrontendEnvironmentConfig = {
   production: true,
   //TODO: Move these configuration to .env file and consume it from there (2022/11/04 - RO - #39)
-  apiUrl: '',
+  apiUrl: 'https://conferentia.onrender.com/api',
   eventId: 'ca40fed4-177c-4a9f-bcfa-225c2b22419d',
 };

--- a/libs/angular-services/src/index.ts
+++ b/libs/angular-services/src/index.ts
@@ -2,3 +2,4 @@ export * from './lib/angular-services.module';
 
 // Services
 export { EventService } from './lib/event.service';
+export { NavigationService } from './lib/navigation.service';

--- a/libs/angular-services/src/lib/navigation.service.spec.ts
+++ b/libs/angular-services/src/lib/navigation.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { NavigationService } from './navigation.service';
+
+describe('NavigationService', () => {
+  let service: NavigationService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(NavigationService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/libs/angular-services/src/lib/navigation.service.ts
+++ b/libs/angular-services/src/lib/navigation.service.ts
@@ -1,0 +1,12 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+import { ActivatedRouteSnapshot } from '@angular/router';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class NavigationService {
+  public currentRoute$: BehaviorSubject<ActivatedRouteSnapshot | null> =
+    new BehaviorSubject<ActivatedRouteSnapshot | null>(null);
+  constructor() {}
+}

--- a/libs/ionic-components/src/lib/fillable-content-page/fillable-content-page.component.html
+++ b/libs/ionic-components/src/lib/fillable-content-page/fillable-content-page.component.html
@@ -1,0 +1,14 @@
+<ion-header>
+  <ion-toolbar>
+    <ion-buttons slot="start">
+      <ion-menu-button></ion-menu-button>
+    </ion-buttons>
+    <ion-title *ngIf="currentRoute$ | async as currentPage">
+      {{ currentPage.data['title'] }}</ion-title
+    >
+  </ion-toolbar>
+</ion-header>
+
+<ion-content
+  ><ng-container *ngTemplateOutlet="content"></ng-container
+></ion-content>

--- a/libs/ionic-components/src/lib/fillable-content-page/fillable-content-page.component.spec.ts
+++ b/libs/ionic-components/src/lib/fillable-content-page/fillable-content-page.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { FillableContentPageComponent } from './fillable-content-page.component';
+
+describe('FillableContentPageComponent', () => {
+  let component: FillableContentPageComponent;
+  let fixture: ComponentFixture<FillableContentPageComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [FillableContentPageComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(FillableContentPageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/ionic-components/src/lib/fillable-content-page/fillable-content-page.component.ts
+++ b/libs/ionic-components/src/lib/fillable-content-page/fillable-content-page.component.ts
@@ -1,0 +1,22 @@
+import { Component, Input, OnInit, TemplateRef } from "@angular/core";
+import { Observable, of } from "rxjs";
+import { ActivatedRouteSnapshot } from "@angular/router";
+import { NavigationService } from "@conferentia/angular-services";
+
+@Component({
+  selector: 'conferentia-fillable-content-page[content]',
+  templateUrl: './fillable-content-page.component.html',
+  styleUrls: ['./fillable-content-page.component.scss'],
+})
+export class FillableContentPageComponent implements OnInit {
+
+  @Input() content: TemplateRef<any> | null = null;
+
+  public currentRoute$: Observable<ActivatedRouteSnapshot | null> = of(null);
+
+  constructor(private navigationService: NavigationService) {}
+
+  ngOnInit() {
+    this.currentRoute$ = this.navigationService.currentRoute$.asObservable();
+  }
+}

--- a/libs/ionic-components/src/lib/ionic-components.module.ts
+++ b/libs/ionic-components/src/lib/ionic-components.module.ts
@@ -2,13 +2,20 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivityCardComponent } from './activity-card/activity-card.component';
 import { SubjectAreaComponent } from './subject-area/subject-area.component';
-import { IonicModule } from "@ionic/angular";
+import { IonicModule } from '@ionic/angular';
+import { FillableContentPageComponent } from './fillable-content-page/fillable-content-page.component';
 
 @NgModule({
   imports: [CommonModule, IonicModule],
-  declarations: [ActivityCardComponent, SubjectAreaComponent],
+  declarations: [
+    ActivityCardComponent,
+    FillableContentPageComponent,
+    SubjectAreaComponent,
+  ],
   exports: [
-    ActivityCardComponent
-  ]
+    ActivityCardComponent,
+    FillableContentPageComponent,
+    SubjectAreaComponent,
+  ],
 })
 export class IonicComponentsModule {}


### PR DESCRIPTION
# Summary

Replaced the way the page headers and contents are declared, resting on the usage of `NavigationService` and `FillableContentPageComponent` to avoid duplicating code.

Fixed the template structure of `AppComponent`, to correctly show the app layout in mobile and desktop versions.

## Libraries
`angular-services`
* Added `NavigationService` to host the data relative to the current selected route.

`ionic-components`:
* Added `FillableContentPageComponent` to avoid redundancy in declaration of Ionic apps pages and headers.