### PR TITLE
[DM, BE, FE-54] FAWHC: Add sponsors to home page right sidebar

### DIFF
--- a/apps/api/src/app/app.module.ts
+++ b/apps/api/src/app/app.module.ts
@@ -9,6 +9,8 @@ import { CommitteeService } from '../committee/committee.service';
 import { CommitteeController } from '../committee/committee.controller';
 import { SubjectAreaController } from '../subject-area/subject-area.controller';
 import { SubjectAreaService } from '../subject-area/subject-area.service';
+import { SponsorService } from '../sponsor/sponsor.service';
+import { SponsorController } from '../sponsor/sponsor.controller';
 
 @Module({
   imports: [
@@ -17,10 +19,16 @@ import { SubjectAreaService } from '../subject-area/subject-area.service';
       envFilePath: '.env',
     }),
   ],
-  controllers: [CommitteeController, EventController, SubjectAreaController],
+  controllers: [
+    CommitteeController,
+    EventController,
+    SponsorController,
+    SubjectAreaController,
+  ],
   providers: [
     CommitteeService,
     EventService,
+    SponsorService,
     SubjectAreaService,
     { provide: ConnectorService, useClass: SanityConnector },
   ],

--- a/apps/api/src/event/event.service.ts
+++ b/apps/api/src/event/event.service.ts
@@ -4,17 +4,22 @@ import { ConnectorService } from '../shared/connectors/connector.service';
 import { SubjectAreaService } from '../subject-area/subject-area.service';
 
 import imageUrlBuilder from '@sanity/image-url';
+import { SponsorService } from '../sponsor/sponsor.service';
 
 @Injectable()
 export class EventService {
   constructor(
     private connectorService: ConnectorService,
+    private sponsorService: SponsorService,
     private subjectAreaService: SubjectAreaService
   ) {}
 
   public async get(id: number): Promise<IEvent> {
     const builder = imageUrlBuilder(this.connectorService.connector);
-    const query = `*[_type == 'event' && _id == '${id}']`;
+    const query = `*[_type == 'event' && _id == '${id}']
+                    { _id, _createdAt, _updatedAt, _type, _rev,
+                     name, image, start_date, end_date, sponsors[]->}`;
+    // {_id, _createdAt, _updatedAt, _type, _rev, name, event->, chairs[]->, viceChairs[]->, members[]->}`
     const queryResult: IEvent[] = await this.connectorService.connector.fetch(
       query,
       {}
@@ -30,6 +35,10 @@ export class EventService {
     return {
       ...result,
       image: result.image ? builder.image(result.image).url() : null,
+      sponsors: result.sponsors.map((sponsor) => ({
+        ...sponsor,
+        image: builder.image(sponsor.image).url(),
+      })),
     };
   }
 

--- a/apps/api/src/sponsor/sponsor.controller.spec.ts
+++ b/apps/api/src/sponsor/sponsor.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SponsorController } from './sponsor.controller';
+
+describe('SponsorController', () => {
+  let controller: SponsorController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [SponsorController],
+    }).compile();
+
+    controller = module.get<SponsorController>(SponsorController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/apps/api/src/sponsor/sponsor.controller.ts
+++ b/apps/api/src/sponsor/sponsor.controller.ts
@@ -1,0 +1,16 @@
+import { Controller, Get, Param } from '@nestjs/common';
+import { SponsorService } from './sponsor.service';
+
+// Events
+import { IEventSponsor } from '@conferentia/models';
+
+@Controller('sponsor')
+export class SponsorController {
+  constructor(private sponsorService: SponsorService) {}
+
+  @Get(':eventId')
+  get(@Param() params): Promise<IEventSponsor[]> {
+    const eventId: number | string = params.eventId;
+    return this.sponsorService.getByEventId(eventId);
+  }
+}

--- a/apps/api/src/sponsor/sponsor.service.spec.ts
+++ b/apps/api/src/sponsor/sponsor.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SponsorService } from './sponsor.service';
+
+describe('SponsorService', () => {
+  let service: SponsorService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [SponsorService],
+    }).compile();
+
+    service = module.get<SponsorService>(SponsorService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/apps/api/src/sponsor/sponsor.service.ts
+++ b/apps/api/src/sponsor/sponsor.service.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@nestjs/common';
+import { ConnectorService } from '../shared/connectors/connector.service';
+import { IEventSponsor } from '@conferentia/models';
+import imageUrlBuilder from '@sanity/image-url';
+
+@Injectable()
+export class SponsorService {
+  constructor(private connectorService: ConnectorService) {}
+
+  public async getByEventId(
+    eventId: number | string
+  ): Promise<IEventSponsor[]> {
+    const builder = imageUrlBuilder(this.connectorService.connector);
+    const query = `*[_type == 'sponsor' && references('${eventId}')]
+                   {_id, _createdAt, _updatedAt, _type, _rev, name, image, url }`;
+    const queryResult: IEventSponsor[] =
+      await this.connectorService.connector.fetch(query, {});
+
+    return queryResult.map((element) => ({
+      ...element,
+      image: builder.image(element.image).url(),
+    }));
+  }
+}

--- a/apps/landing-unl-seminar-v1/src/app/home/home.page.html
+++ b/apps/landing-unl-seminar-v1/src/app/home/home.page.html
@@ -4,53 +4,78 @@
 
 <ng-template #homeContent>
   <ng-container *ngIf="(currentEvent$ | async) as currentEvent">
-    <ion-card>
-      <ion-card-header>
-        <ion-card-title
-          >French Argentinean Workshop on Heterogeneous Catalysis
-        </ion-card-title>
-      </ion-card-header>
+    <ion-grid>
+      <ion-row>
+        <ion-col size="12" size-lg="8">
+          <ion-card>
+            <ion-card-header>
+              <ion-card-title
+                >French Argentinean Workshop on Heterogeneous Catalysis
+              </ion-card-title>
+            </ion-card-header>
 
-      <ion-card-content>
-        The Institute of Research on Catalysis and Petrochemistry, “Ing. José
-        Miguel Parera“, INCAPE (CONICET - UNL), organizes the French Argentinean
-        Workshop on Heterogeneous Catalysis. It will be held within the
-        framework of an international cooperation project between the groups led
-        by Dr. Florence Epron (Institut de Chimie des Milieux et Matériaux de
-        Poitiers, IC2MP, France) and Dr. Carlos Pieck (INCAPE, Argentina):
-        “International Research Proyect, OLECAT: Catalyseurs pour la production
-        d’olefines”. The entire scientific community is invited to participate,
-        from April 11 to 13, 2023 in Santa Fe, Argentina.
-      </ion-card-content>
-    </ion-card>
-    <ion-card>
-      <ion-card-header>
-        <ion-card-title>Objectives</ion-card-title>
-      </ion-card-header>
+            <ion-card-content>
+              The Institute of Research on Catalysis and Petrochemistry, “Ing.
+              José Miguel Parera“, INCAPE (CONICET - UNL), organizes the French
+              Argentinean Workshop on Heterogeneous Catalysis. It will be held
+              within the framework of an international cooperation project
+              between the groups led by Dr. Florence Epron (Institut de Chimie
+              des Milieux et Matériaux de Poitiers, IC2MP, France) and Dr.
+              Carlos Pieck (INCAPE, Argentina): “International Research Proyect,
+              OLECAT: Catalyseurs pour la production d’olefines”. The entire
+              scientific community is invited to participate, from April 11 to
+              13, 2023 in Santa Fe, Argentina.
+            </ion-card-content>
+          </ion-card>
+          <ion-card>
+            <ion-card-header>
+              <ion-card-title>Objectives</ion-card-title>
+            </ion-card-header>
 
-      <ion-card-content>
-        To promote the updating of scientific-technological advances in the
-        fields of heterogeneous catalysis and engineering. To favor the
-        generation of new international cooperation agreements.
-      </ion-card-content>
-    </ion-card>
-    <ion-card>
-      <ion-card-header>
-        <ion-card-title>Topics</ion-card-title>
-      </ion-card-header>
-      <ion-card-content>
-        <ion-grid>
-          <ion-row>
-            <ng-container *ngFor="let subjectArea of currentEvent.subjectAreas">
-              <ion-col size="12" size-md="6" size-lg="4">
-                <conferentia-subject-area
-                  [subjectArea]="subjectArea"
-                ></conferentia-subject-area>
-              </ion-col>
-            </ng-container>
-          </ion-row>
-        </ion-grid>
-      </ion-card-content>
-    </ion-card>
+            <ion-card-content>
+              To promote the updating of scientific-technological advances in
+              the fields of heterogeneous catalysis and engineering. To favor
+              the generation of new international cooperation agreements.
+            </ion-card-content>
+          </ion-card>
+          <ion-card>
+            <ion-card-header>
+              <ion-card-title>Topics</ion-card-title>
+            </ion-card-header>
+            <ion-card-content>
+              <ion-grid>
+                <ion-row>
+                  <ng-container
+                    *ngFor="let subjectArea of currentEvent.subjectAreas"
+                  >
+                    <ion-col size="12" size-md="6">
+                      <conferentia-subject-area
+                        [subjectArea]="subjectArea"
+                      ></conferentia-subject-area>
+                    </ion-col>
+                  </ng-container>
+                </ion-row>
+              </ion-grid>
+            </ion-card-content>
+          </ion-card>
+        </ion-col>
+        <ion-col size="12" size-lg="4">
+          <ion-card id="sponsors">
+            <ion-card-header>
+              <ion-card-subtitle class="ion-text-center">
+                Host Institutions and Sponsors
+              </ion-card-subtitle>
+            </ion-card-header>
+            <ion-card-content>
+              <ng-container *ngFor="let sponsor of currentEvent.sponsors">
+                <a [href]="sponsor.url">
+                  <ion-img [src]="sponsor.image"></ion-img>
+                </a>
+              </ng-container>
+            </ion-card-content>
+          </ion-card>
+        </ion-col>
+      </ion-row>
+    </ion-grid>
   </ng-container>
 </ng-template>

--- a/apps/landing-unl-seminar-v1/src/app/home/home.page.scss
+++ b/apps/landing-unl-seminar-v1/src/app/home/home.page.scss
@@ -1,0 +1,11 @@
+#sponsors {
+  ion-card-content {
+    display: flex;
+    justify-content: space-evenly;
+    flex-wrap: wrap;
+  }
+  ion-img {
+    max-height: 240px;
+    margin-bottom: 24px;
+  }
+}

--- a/apps/studio/schemas/event-sponsor.ts
+++ b/apps/studio/schemas/event-sponsor.ts
@@ -1,0 +1,36 @@
+export default {
+  title: 'Patrocinadores',
+  name: 'sponsor',
+  type: 'document',
+  description: 'Patrocinadores de un evento',
+  fields: [
+    {
+      title: 'Evento',
+      name: 'event',
+      type: 'reference',
+      description: 'Evento al que pertenece la actividad.',
+      to: [{ type: 'event' }],
+      validation: (Rule) => Rule.required(),
+    },
+    {
+      title: 'Nombre',
+      name: 'name',
+      type: 'string',
+      description: 'Nombre del patrocinador.',
+      validation: (Rule) => Rule.required(),
+    },
+    {
+      title: 'Logo',
+      name: 'image',
+      type: 'image',
+      description: 'Logo del patrocinador.',
+      validation: (Rule) => Rule.required(),
+    },
+    {
+      title: 'Enlace',
+      name: 'url',
+      type: 'string',
+      description: 'Enlace al sitio del patrocinador',
+    },
+  ],
+};

--- a/apps/studio/schemas/event.ts
+++ b/apps/studio/schemas/event.ts
@@ -56,9 +56,33 @@ export default {
       },
       validation: (Rule) => Rule.required(),
     },
+    // options: {
+    //   filter: ({ document }) => {
+    //     // TODO: Put this filter to work (see #15)
+    //     // Check that the assigned Sponsors belongs to the same Event each sponsor belongs to
+    //     return {
+    //       filter: 'event == $event',
+    //       params: {
+    //         event: document.event,
+    //       },
+    //     };
+    //   },
+    // },
+    {
+      title: 'Patrocinadores',
+      name: 'sponsors',
+      type: 'array',
+      description: 'Patrocinadores del evento',
+      of: [
+        {
+          type: 'reference',
+          to: { type: 'sponsor' },
+        },
+      ],
+    },
   ],
   initialValue: {
     start_date: new Date(),
-    end_date: new Date()
-  }
+    end_date: new Date(),
+  },
 };

--- a/apps/studio/schemas/schema.ts
+++ b/apps/studio/schemas/schema.ts
@@ -10,6 +10,7 @@ import activityType from './activity-type';
 import commiteeArea from './committee-area';
 import commiteeMember from './commitee-member';
 import event from './event';
+import eventSponsor from './event-sponsor';
 import subjectArea from './subject-area';
 
 // Then we give our schema to the builder and provide the result to Sanity
@@ -24,6 +25,7 @@ export default createSchema({
     commiteeArea,
     commiteeMember,
     event,
-    subjectArea
+    eventSponsor,
+    subjectArea,
   ]),
 });

--- a/libs/models/src/index.ts
+++ b/libs/models/src/index.ts
@@ -8,6 +8,7 @@ export { IParticipant } from './lib/participant.interface';
 export { ICommitteeArea } from './lib/committee-area.interface';
 export { ICommitteeMember } from './lib/committee-member.interface';
 export { ISubjectArea } from './lib/subject-area.interface';
+export { IEventSponsor } from './lib/event-sponsor.interface';
 
 export { IAudit } from './lib/audit.interface';
 

--- a/libs/models/src/lib/event-sponsor.interface.ts
+++ b/libs/models/src/lib/event-sponsor.interface.ts
@@ -1,0 +1,7 @@
+import { IAudit } from '@conferentia/models';
+
+export interface IEventSponsor extends IAudit {
+  name: string;
+  image: string;
+  url?: string;
+}

--- a/libs/models/src/lib/event.interface.ts
+++ b/libs/models/src/lib/event.interface.ts
@@ -1,5 +1,6 @@
 import { IAudit } from './audit.interface';
 import { ISubjectArea } from './subject-area.interface';
+import { IEventSponsor } from "./event-sponsor.interface";
 
 export interface IEvent extends IAudit {
   title: string;
@@ -7,5 +8,6 @@ export interface IEvent extends IAudit {
   startDate: string | Date;
   endDate: string | Date;
   image?: string;
+  sponsors?: IEventSponsor[];
   subjectAreas?: ISubjectArea[];
 }


### PR DESCRIPTION
# Summary

## Domain
* Added `EventSponsor` model.
* Added optional `sponsors` property to `Event` model.

## Backend
* Added controller and event to fetch and manage `EventSponsor` entities.
* Added `EventSponsor` schema for Sanity CMS.
* Added `sponsors` property to `Event` schema in Sanity CMS.

## Frontend
* Added programatic display of `EventSponsor` properties belonging to the current `Event` in landing page.
