### PR TITLE
[FE, CO-#91] Add first draft of the Speakers page for FAWHC 2023 event

### DIFF
--- a/apps/api/src/participant/participant.service.ts
+++ b/apps/api/src/participant/participant.service.ts
@@ -11,7 +11,7 @@ export class ParticipantService {
     const builder = imageUrlBuilder(this.connectorService.connector);
     const query = `*[_type == 'participant' && references('${eventId}')]
                     { _id, _createdAt, _updatedAt, _type, _rev,
-                     title, courtesyName, firstName, lastName, avatar, description }`;
+                     institution, courtesyName, firstName, lastName, avatar, curriculum }`;
     const result: IParticipant[] = await this.connectorService.connector.fetch(
       query,
       {}
@@ -20,7 +20,7 @@ export class ParticipantService {
     // ToDo: #60 - Remove code duplication when fetching sorted domain entities, via use of the Sorting design pattern (RO - 2022/11/15)
     return result.map((participant) => ({
       ...participant,
-      avatar: builder.image(participant.avatar).url(),
+      avatar: participant.avatar ? builder.image(participant.avatar).url() : null,
     }));
   }
 }

--- a/apps/landing-unl-seminar-v1/src/app/keynote-speakers/keynote-speakers.page.html
+++ b/apps/landing-unl-seminar-v1/src/app/keynote-speakers/keynote-speakers.page.html
@@ -1,9 +1,19 @@
-<conferentia-fillable-content-page [content]="keynoteSpeakersContent"></conferentia-fillable-content-page>
+<conferentia-fillable-content-page
+  [content]="keynoteSpeakersContent"
+></conferentia-fillable-content-page>
 
 <ng-template #keynoteSpeakersContent>
-  <ion-card>
-    <ion-card-content>
-      Available shortly.
-    </ion-card-content>
-  </ion-card>
+  <ng-container *ngIf="(participants$ | async) as participants">
+    <ion-grid>
+      <ion-row>
+        <ng-container *ngFor="let participant of participants">
+          <ion-col size="12" size-md="6">
+            <conferentia-participant-card
+              [participant]="participant"
+            ></conferentia-participant-card>
+          </ion-col>
+        </ng-container>
+      </ion-row>
+    </ion-grid>
+  </ng-container>
 </ng-template>

--- a/apps/landing-unl-seminar-v1/src/app/keynote-speakers/keynote-speakers.page.ts
+++ b/apps/landing-unl-seminar-v1/src/app/keynote-speakers/keynote-speakers.page.ts
@@ -1,12 +1,28 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, inject } from '@angular/core';
+import { Observable, of, switchMap } from 'rxjs';
+import { IEvent, IParticipant } from '@conferentia/models';
+import {
+  EventService,
+  ParticipantService,
+} from '@conferentia/angular-services';
 
 @Component({
   selector: 'conferentia-keynote-speakers',
   templateUrl: './keynote-speakers.page.html',
   styleUrls: ['./keynote-speakers.page.scss'],
 })
-export class KeynoteSpeakersPage implements OnInit {
-  constructor() {}
+export class KeynoteSpeakersPage {
+  public participants$: Observable<IParticipant[] | null> = of(null);
+  public currentEvent$: Observable<IEvent | null> = of(null);
 
-  ngOnInit() {}
+  constructor() {
+    const eventService = inject(EventService);
+    const participantService = inject(ParticipantService);
+    this.currentEvent$ = eventService.currentEvent$.asObservable();
+    this.participants$ = this.currentEvent$.pipe(
+      switchMap((event) =>
+        participantService.getByEventId((event as IEvent)._id)
+      )
+    );
+  }
 }

--- a/apps/studio/schemas/participant.ts
+++ b/apps/studio/schemas/participant.ts
@@ -8,13 +8,15 @@ export default {
       firstName: 'firstName',
       lastName: 'lastName',
       courtesyName: 'courtesyName',
-      avatar: 'avatar'
+      avatar: 'avatar',
+      institution: 'institution'
     },
     prepare(selection) {
-      const { firstName, lastName, courtesyName, avatar } = selection;
+      const { firstName, lastName, courtesyName, avatar, institution } = selection;
       const courtesyString = courtesyName ? `, ${courtesyName}.` : '';
       return {
         title: `${firstName} ${lastName}${courtesyString}`,
+        subtitle: institution,
         media: avatar
       };
     },

--- a/libs/ionic-components/src/lib/participant-card/participant-card.component.html
+++ b/libs/ionic-components/src/lib/participant-card/participant-card.component.html
@@ -1,17 +1,19 @@
 <ion-card *ngIf="participant">
   <ion-card-header>
-    <ion-grid>
+    <ion-grid class="ion-no-padding">
       <ion-row>
-        <ion-col size="4">
-          <ion-avatar>
-            <img
-              alt="Silhouette of a person's head"
-              [src]="
-                participant.avatar
-                  ? participant.avatar
-                  : 'https://ionicframework.com/docs/img/demos/avatar.svg'
-              "
-          /></ion-avatar>
+        <ion-col size="auto">
+          <div style="width: 100px">
+            <ion-avatar>
+              <img
+                alt="Silhouette of a person's head"
+                [src]="
+                  participant.avatar
+                    ? participant.avatar
+                    : 'https://ionicframework.com/docs/img/demos/avatar.svg'
+                "
+            /></ion-avatar>
+          </div>
         </ion-col>
         <ion-col>
           <ion-card-title>
@@ -22,9 +24,19 @@
             {{ participant.firstName }}
             {{ participant.lastName }}</ion-card-title
           >
-          <ion-card-subtitle>{{ title }}</ion-card-subtitle>
+          <ion-card-subtitle>{{ participant.institution }}</ion-card-subtitle>
         </ion-col>
       </ion-row>
     </ion-grid>
   </ion-card-header>
+
+  <ng-container *ngIf="participant.curriculum">
+    <ion-card-content class="ion-text-justify">
+      <ion-label>
+        <ng-container *ngFor="let paragraph of parsedCurriculum">
+          <div class="ion-margin-bottom">{{ paragraph }}</div>
+        </ng-container>
+      </ion-label>
+    </ion-card-content>
+  </ng-container>
 </ion-card>

--- a/libs/ionic-components/src/lib/participant-card/participant-card.component.ts
+++ b/libs/ionic-components/src/lib/participant-card/participant-card.component.ts
@@ -13,7 +13,12 @@ export class ParticipantCardComponent implements OnInit {
   @Input() participant: IParticipant | undefined;
   @Input() title: string = '';
 
+  public parsedCurriculum: string[] | undefined;
+
   constructor() {}
 
-  ngOnInit(): void {}
+  ngOnInit(): void {
+    this.parsedCurriculum = this.participant?.curriculum?.split('\n'); // ToDo: Adapt this assignation when paragraph parser component is available #92 (RO - 2022/11/26)
+
+  }
 }

--- a/libs/ionic-components/src/lib/schedule/schedule.component.html
+++ b/libs/ionic-components/src/lib/schedule/schedule.component.html
@@ -10,7 +10,7 @@
             <ion-item>
               <div
                 class="detail"
-                [ngStyle]="{backgroundColor: activity.type?.backgroundColor}"
+                [ngStyle]="{backgroundColor: activity.type.backgroundColor}"
               ></div>
               <ion-thumbnail slot="start" *ngIf="activity.image">
                 <img

--- a/libs/models/src/lib/participant.interface.ts
+++ b/libs/models/src/lib/participant.interface.ts
@@ -9,7 +9,7 @@ export interface IParticipant extends IAudit {
   courtesyName?: string;
   institution?: string;
   avatar?: string;
-  curriculum?: string[];
+  curriculum?: string; // ToDo: Adapt the type of this property according to what's defined in #92 (RO - 2022/11/26)
 }
 
 // ToDo: Replace the hardcoded type for Participant Role for this programmatic interface (#62 - RO - 2022/11/16)


### PR DESCRIPTION
# Summary
## Backend
* Added `institution` to participants query. Added validation for participants without image in service.

## Frontend
* Updated `ParticipantCardComponent`: added participants institution, curriculum and fixed participant avatar's width.
* Schedule: removed unrequired optional chain operator use.

## Domain
* Changed the type of the `curriculum` property in `Participant` model.

## Tooling
* Updated schema for `Participant` to show the participant institution in Sanity Studio preview.

# Screenshot
![image](https://user-images.githubusercontent.com/32349705/204141368-262e3226-a16d-4aef-8769-2e332d9fcba1.png)
