### PR TITLE
[DM,BE,FE-#111] FAWHC 2023: Identify sent abstracts via SubjectArea and ID

### DIFF
--- a/apps/api/src/subject-area/subject-area.service.ts
+++ b/apps/api/src/subject-area/subject-area.service.ts
@@ -17,7 +17,7 @@ export class SubjectAreaService {
   public async get(eventId: number | string): Promise<ISubjectArea[]> {
     const builder = imageUrlBuilder(this.connectorService.connector);
     const query = `*[_type == 'subjectArea' && references('${eventId}')]
-                   {_id, _createdAt, _updatedAt, _type, _rev, name, image, order, event-> } | order(order)`;
+                   {_id, _createdAt, _updatedAt, _type, _rev, name, code, image, order, event-> } | order(order)`;
     const result = await this.connectorService.connector.fetch(query, {});
     return result
       .map((subjectArea) => ({

--- a/apps/landing-unl-seminar-v1/src/app/abstract-submission/abstract-submission.page.html
+++ b/apps/landing-unl-seminar-v1/src/app/abstract-submission/abstract-submission.page.html
@@ -38,9 +38,12 @@
                   <li>
                     You can submit your abstract (one page) in PDF file from 5
                     December 2022. Registered users can access the submission of
-                    papers, with Email and password. Access the platform for
-                    submitting abstract by clicking
-                    <a href="" (click)="navigateToRegistration()">here</a>.
+                    papers, with Email and password.
+                    <ng-container *ngIf="!(currentUser$ | async) as currentUser">
+                      Access the platform for
+                      submitting abstracts by clicking
+                      <a href (click)="navigateToRegistration()">here</a>.
+                    </ng-container>
                   </li>
                   <li>
                     To check for your submitted abstracts and their statuses,

--- a/apps/studio/schemas/subject-area.ts
+++ b/apps/studio/schemas/subject-area.ts
@@ -19,6 +19,13 @@ export default {
       validation: (Rule) => Rule.required(),
     },
     {
+      title: 'Código',
+      name: 'code',
+      type: 'string',
+      description: 'Código asignado a las áreas temáticas.',
+      validation: (Rule) => Rule.required(),
+    },
+    {
       title: 'Imagen Alusiva',
       name: 'image',
       type: 'image',

--- a/libs/ionic-pages/src/lib/user-profile/user-profile.page.html
+++ b/libs/ionic-pages/src/lib/user-profile/user-profile.page.html
@@ -107,6 +107,14 @@
               <ion-grid>
                 <ion-row>
                   <ion-col>
+                    <ion-label>
+                      <strong>ID:</strong> {{abstract.subjectArea.code + ' - ' + abstract._id.toUpperCase()}}
+                    </ion-label>
+                  </ion-col>
+                  <ion-col></ion-col>
+                </ion-row>
+                <ion-row>
+                  <ion-col>
                     <ion-label
                       ><strong>Title: </strong
                       ><a [href]="abstract.fileUrl"

--- a/libs/models/src/lib/subject-area.interface.ts
+++ b/libs/models/src/lib/subject-area.interface.ts
@@ -2,6 +2,7 @@ import { IAudit, IEvent } from '@conferentia/models';
 
 export interface ISubjectArea extends IAudit {
   name: string;
+  code: string;
   event?: IEvent;
   image?: string;
 }


### PR DESCRIPTION
# Summary
* Added `code` property to `SubjectArea` schema.
* Added `code` property to `SubjectArea` domain model.
* Fetched SubjectArea instances with the `code` property under `SubjectAreaService` in the backend.
* Abstracts submitted visible under the `User Profile` page now display an ID based on the `code` property and the document ID of the `Abstract` instance.

## Other changes
* Added conditional display for the login link under Abstract Submission page.

## Screenshots
![image](https://user-images.githubusercontent.com/32349705/207903450-18b17814-cd3a-4dce-a787-e5024ddd7f5b.png)
