### PR TITLE
[BE, DM, FE, CO-#114] FAWHC 2022: Add basic id assignation method

### DIFF
--- a/apps/api/src/abstract/abstract.service.ts
+++ b/apps/api/src/abstract/abstract.service.ts
@@ -6,7 +6,7 @@ import * as fs from 'fs';
 
 @Injectable()
 export class AbstractService {
-  // ToDo: Check on how to programatically asign the typing to the connector (RO - 2022/12/05 - #105)
+  // ToDo: Check on how to programatically assign the typing to the connector (RO - 2022/12/05 - #105)
   private connector: SanityClient;
 
   constructor(private connectorService: ConnectorService) {
@@ -24,6 +24,7 @@ export class AbstractService {
                         event->,
                         user->,
                         title,
+                        identifier,
                         keywords,
                         status,
                         format,
@@ -51,6 +52,7 @@ export class AbstractService {
                         event->,
                         user->,
                         title,
+                        identifier,
                         keywords,
                         status,
                         format,
@@ -102,6 +104,7 @@ export class AbstractService {
     // Add abstract document to the transaction
     const abstractTransaction = this.connector.transaction().create({
       _type: 'abstract',
+      identifier: await this.generateIdentifier(),
       event: { _type: 'reference', _ref: payload.eventId },
       user: { _type: 'reference', _ref: payload.uploaderUserId },
       title: payload.abstract.title,
@@ -134,5 +137,14 @@ export class AbstractService {
       });
 
     return this.getById(result.documentIds[0]);
+  }
+
+  private async generateIdentifier() {
+    // Fetch count of existing abstracts to generate an ID
+    const abstractCount = await this.connector.fetch(
+      `count(*[_type == 'abstract'])`,
+      {}
+    );
+    return `${abstractCount+1}`;
   }
 }

--- a/apps/landing-unl-seminar-v1/src/app/abstract-submission/abstract-submission.page.html
+++ b/apps/landing-unl-seminar-v1/src/app/abstract-submission/abstract-submission.page.html
@@ -199,7 +199,7 @@
               <ion-text color="primary"
                 ><h2>Abstract submission deadline</h2></ion-text
               >
-              <ion-text><h3>10 February 2022</h3></ion-text>
+              <ion-text><h3>10 February 2023</h3></ion-text>
             </ion-card-content>
           </ion-card>
           <ion-card>

--- a/apps/landing-unl-seminar-v1/src/app/general-information/general-information.page.html
+++ b/apps/landing-unl-seminar-v1/src/app/general-information/general-information.page.html
@@ -40,6 +40,11 @@
                     Heterogeneous Catalysis was declared of interest to the
                     Province of Santa Fe by Decree No. 2379.
                   </p>
+                  <p class="ion-margin-bottom">
+                    Also the Chamber of Deputies of the province of Santa Fe
+                    declares it of interest in the Session Room on 24 November,
+                    2022.
+                  </p>
                 </ion-card-content>
               </ion-col>
               <ion-col size="12" size-lg="3">

--- a/apps/studio/schemas/abstract.ts
+++ b/apps/studio/schemas/abstract.ts
@@ -73,6 +73,13 @@ export default {
       validation: (Rule) => Rule.required(),
     },
     {
+      title: 'Identificador',
+      name: 'identifier',
+      type: 'string',
+      description: 'Código de identificación del Abstract',
+      validation: (Rule) => Rule.required(),
+    },
+    {
       title: 'Formato',
       name: 'format',
       type: 'string',

--- a/libs/ionic-pages/src/lib/user-profile/user-profile.page.html
+++ b/libs/ionic-pages/src/lib/user-profile/user-profile.page.html
@@ -108,7 +108,7 @@
                 <ion-row>
                   <ion-col>
                     <ion-label>
-                      <strong>ID:</strong> {{abstract.subjectArea.code + ' - ' + abstract._id.toUpperCase()}}
+                      <strong>ID:</strong> {{abstract.subjectArea.code + '-' + abstract.identifier.toUpperCase()}}
                     </ion-label>
                   </ion-col>
                   <ion-col></ion-col>

--- a/libs/models/src/lib/abstract.interface.ts
+++ b/libs/models/src/lib/abstract.interface.ts
@@ -8,6 +8,7 @@ import {
 
 export interface Abstract extends IAudit {
   title: string;
+  identifier: string;
   authors: Author[];
   subjectArea: ISubjectArea;
   keywords: string;


### PR DESCRIPTION
# Summary
* Added new `identifier` field to be used as an id for abstracts.
* Added display of the new `identifier` field under the User Profile view.

## Other changes
* Corrected deadline date.
* Added missing paragraph under General Information page.