### PR TITLE
[FE] - Add time zone as env variable for frontend apps

### DIFF
--- a/apps/landing-unl-seminar-v1/src/environments/environment.ts
+++ b/apps/landing-unl-seminar-v1/src/environments/environment.ts
@@ -2,6 +2,7 @@ export const environment = {
   production: false,
   apiUrl: 'http://localhost:3334/api',
   eventId: 'ca40fed4-177c-4a9f-bcfa-225c2b22419d',
+  timeZone: -3,
   auth0: {
     domain: 'dev-0wyaah0g.us.auth0.com',
     clientId: 'JDyryGkwVp1H1uP3risPd0qo2c6il9NO',

--- a/libs/angular-services/src/lib/services/activity.service.ts
+++ b/libs/angular-services/src/lib/services/activity.service.ts
@@ -6,6 +6,8 @@ import { Observable, of, switchMap } from 'rxjs';
 
 // Libraries
 import dayjs from 'dayjs';
+import * as utc from 'dayjs/plugin/utc';
+dayjs.extend(utc);
 
 @Injectable({
   providedIn: 'root',
@@ -26,8 +28,14 @@ export class ActivityService extends HttpService {
             ...scheduleDay,
             activities: scheduleDay.activities.map((activity) => ({
               ...activity,
-              startDate: formatActivitiesTime(activity.startDate),
-              endDate: formatActivitiesTime(activity.endDate),
+              startDate: formatActivitiesTime(
+                activity.startDate,
+                this.env.timeZone
+              ),
+              endDate: formatActivitiesTime(
+                activity.endDate,
+                this.env.timeZone
+              ),
             })),
           }))
         );
@@ -36,5 +44,7 @@ export class ActivityService extends HttpService {
   }
 }
 
-const formatActivitiesTime = (dateTime: string | Date) =>
-  dayjs(dateTime).format('hh:mm');
+const formatActivitiesTime = (
+  dateTime: string | Date,
+  timeZone: number | string = 0
+) => dayjs(dateTime).utcOffset(timeZone).format('hh:mm');

--- a/libs/models/src/lib/frontend-environment-config.interface.ts
+++ b/libs/models/src/lib/frontend-environment-config.interface.ts
@@ -3,9 +3,10 @@ export interface IFrontendEnvironmentConfig {
   apiUrl: string;
   //TODO: Check if eventId is still required after moving the config to .env files (2022/11/04 - RO - #39)
   eventId: string;
+  timeZone: string | number;
   auth0: {
     domain: string;
     clientId: string;
     audience: string;
-  }
+  };
 }

--- a/scripts/set-environment.ts
+++ b/scripts/set-environment.ts
@@ -18,6 +18,7 @@ export const environment = {
    production: ${isProduction},
    apiUrl: '${process.env.API_URL}',
    eventId: '${process.env.EVENT_ID}',
+   timeZone: '${process.env.TIME_ZONE},
    auth0: {
      domain: '${process.env.AUTH0_DOMAIN}',
      clientId: '${process.env.CLIENT_ID}',


### PR DESCRIPTION
# Summary
* Add `timeZone` field to `IFrontendEnvironmentConfig`.
* Format dates in `ActivityService` using utc as a parameter.